### PR TITLE
Set Zed extension version to 1.0.0

### DIFF
--- a/packages/zed/extension.toml
+++ b/packages/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "karma-theme"
 name = "Karma Theme"
-version = "0.0.1"
+version = "1.0.0"
 schema_version = 1
 authors = ["Sreetam Das"]
 description = "A colorful dark theme"


### PR DESCRIPTION
Sets the initial Zed extension release version to 1.0.0.
